### PR TITLE
[MNT] Replaced validation errors with warnings in `ResultFolder` load

### DIFF
--- a/remayn/result_set/result_set.py
+++ b/remayn/result_set/result_set.py
@@ -447,10 +447,10 @@ class ResultFolder(ResultSet):
         if len(json_files) != len(pkl_files):
             for json_file in json_files:
                 if json_file.with_suffix(".pkl") not in pkl_files:
-                    raise FileNotFoundError(
+                    warnings.warn(
                         f"Could not find pkl file for json file {json_file}",
                     )
-            raise FileNotFoundError(
+            warnings.warn(
                 f"Number of json files ({len(json_files)}) does not match"
                 f" number of pkl files ({len(pkl_files)})",
             )

--- a/remayn/result_set/result_set.py
+++ b/remayn/result_set/result_set.py
@@ -447,7 +447,7 @@ class ResultFolder(ResultSet):
         if len(json_files) != len(pkl_files):
             for json_file in json_files:
                 if json_file.with_suffix(".pkl") not in pkl_files:
-                    warnings.warn(
+                    raise FileNotFoundError(
                         f"Could not find pkl file for json file {json_file}",
                     )
             warnings.warn(

--- a/remayn/result_set/tests/test_result_set.py
+++ b/remayn/result_set/tests/test_result_set.py
@@ -299,10 +299,8 @@ def test_result_folder_load_error(result_list, result_path):
 
     (result_list[0].base_path / f"{result_list[0].id}.pkl").unlink()
 
-    with pytest.raises(UserWarning, match="Could not find"):
-        warnings.filterwarnings("error")
+    with pytest.raises(FileNotFoundError, match="Could not find"):
         ResultFolder(result_path)
-        warnings.resetwarnings()
 
     (result_list[0].base_path / f"{result_list[0].id}.json").unlink()
 

--- a/remayn/result_set/tests/test_result_set.py
+++ b/remayn/result_set/tests/test_result_set.py
@@ -299,14 +299,17 @@ def test_result_folder_load_error(result_list, result_path):
 
     (result_list[0].base_path / f"{result_list[0].id}.pkl").unlink()
 
-    with pytest.raises(FileNotFoundError, match="Could not find"):
+    with pytest.raises(UserWarning, match="Could not find"):
+        warnings.filterwarnings("error")
         ResultFolder(result_path)
+        warnings.resetwarnings()
 
     (result_list[0].base_path / f"{result_list[0].id}.json").unlink()
 
     (result_list[1].base_path / f"{result_list[1].id}.json").unlink()
 
-    with pytest.raises(FileNotFoundError, match="Number of json"):
+    with pytest.raises(UserWarning, match="Number of json"):
+        warnings.filterwarnings("error")
         ResultFolder(result_path)
 
 


### PR DESCRIPTION
`ResultFolder` load function checks that the number of json and pickle file in the results directory is the same. This check helps detecting invalid result files. However, when this check is performed while multiple experiments are running, there are cases when a false positive is detected. This is mostly due to the fact that the pickle file takes some time to be written and the json file is created after it.

For this reason, the exceptions that were raised if the check failed, have been replaced with warnings.