### PR TITLE
[MNT] Set maximum python version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "REsults MAde easY in pythoN"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.8,<3.13"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: BSD License",


### PR DESCRIPTION
Set maximum python version in pyproject.toml to <3.13.